### PR TITLE
Correctly handle getting 1 item off a 2+ item list

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,8 @@ module.exports = function last(arr, n) {
   }
 
   n = isNumber(n) ? +n : 1;
-  if (n === 1 && len === 1) {
-    return arr[0];
+  if (n === 1) {
+    return arr[len - 1];
   }
 
   var res = new Array(n);

--- a/test.js
+++ b/test.js
@@ -25,8 +25,8 @@ describe('last', function () {
   });
 
   it('should return the last element in the array:', function () {
-    assert.equal(last(['a', 'b', 'c', 'd', 'e', 'f']), 'f');
-    assert.equal(last(['a', 'b', 'c', 'd', 'e', 'f'], 1), 'f');
+    assert.strictEqual(last(['a', 'b', 'c', 'd', 'e', 'f']), 'f');
+    assert.strictEqual(last(['a', 'b', 'c', 'd', 'e', 'f'], 1), 'f');
   });
 
   it('should the last n elements of the array:', function () {


### PR DESCRIPTION
Behavior diverged from the docs in 1.1 and the tests didn't catch the issue because they weren't asserting strict equality
