### PR TITLE
Performance Boost

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,26 +5,21 @@
  * Released under the MIT License.
  */
 
-var isNumber = require('is-number');
-
-module.exports = function last(arr, n) {
+module.exports = function (arr, n) {
   if (!Array.isArray(arr)) {
     throw new Error('expected the first argument to be an array');
   }
 
   var len = arr.length;
-  if (len === 0) {
-    return null;
-  }
+  if (len === 0) return null;
 
-  n = isNumber(n) ? +n : 1;
-  if (n === 1) {
-    return arr[len - 1];
-  }
+  n = n && parseInt(n, 10) || 1;
+
+  if (n === 1) return arr[len - 1];
 
   var res = new Array(n);
   while (n--) {
     res[n] = arr[--len];
   }
   return res;
-};
+}

--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ module.exports = function (arr, n) {
   n = n && parseInt(n, 10) || 1;
 
   if (n === 1) return arr[len - 1];
+  if (n >= len) return arr;
 
   var res = new Array(n);
   while (n--) {

--- a/package.json
+++ b/package.json
@@ -25,9 +25,6 @@
   "scripts": {
     "test": "mocha"
   },
-  "dependencies": {
-    "is-number": "^4.0.0"
-  },
   "devDependencies": {
     "ansi-bold": "^0.1.1",
     "array-slice": "^1.0.0",


### PR DESCRIPTION
Yo~!

This improves performance significantly on any number slicing or parsing. It also defaults any `NaN`-derived value to `1`, the default.

I also included a simple solution to #7.

Custom benchmarks were setup as the current ones seem to be outdated & I couldn't get them to work =/ These were made with `benchmark.js` and your `randomatic` lib for fixtures. I can PR this as well if you're interested.

***Before***

```
# Last Item (1000)
  array-last x 167,157,582 ops/sec ±0.16% (97 runs sampled)

# Last Item (1000000)
  array-last x 166,438,057 ops/sec ±0.58% (95 runs sampled)

# Last 10 Items (1000)
  array-last x 29,290,764 ops/sec ±0.25% (95 runs sampled)

# Last 10 Items (1000000)
  array-last x 29,418,958 ops/sec ±0.28% (96 runs sampled)

# Last "10" Items (1000)
  array-last x 17,594,653 ops/sec ±0.76% (98 runs sampled)

# Last "10" Items (1000000)
  array-last x 17,747,237 ops/sec ±1.69% (96 runs sampled)

# Last N+1 Items (1000)
  array-last x 921 ops/sec ±0.14% (96 runs sampled)

# Last N+1 Items (1000000)
  array-last x 74.02 ops/sec ±3.78% (64 runs sampled)
```

***After***

```
# Last Item (1000)
  array-last x 167,646,149 ops/sec ±0.18% (95 runs sampled)

# Last Item (1000000)
  array-last x 167,290,607 ops/sec ±0.62% (94 runs sampled)

# Last 10 Items (1000)
  array-last x 35,060,211 ops/sec ±0.59% (90 runs sampled)

# Last 10 Items (1000000)
  array-last x 35,672,206 ops/sec ±0.21% (98 runs sampled)

# Last "10" Items (1000)
  array-last x 23,583,987 ops/sec ±0.82% (92 runs sampled)

# Last "10" Items (1000000)
  array-last x 23,344,110 ops/sec ±1.93% (98 runs sampled)

# Last N+1 Items (1000)
  array-last x 132,743,603 ops/sec ±0.34% (96 runs sampled)

# Last N+1 Items (1000000)
  array-last x 132,547,623 ops/sec ±0.62% (95 runs sampled)
```